### PR TITLE
Feature/workers

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -34,7 +34,8 @@
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [],
+            "webWorkerTsConfig": "tsconfig.worker.json"
           },
           "configurations": {
             "production": {
@@ -93,7 +94,8 @@
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [],
+            "webWorkerTsConfig": "tsconfig.worker.json"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "@angular/platform-browser-dynamic": "^18.2.0",
     "@angular/router": "^18.2.0",
     "rxjs": "~7.8.0",
+    "text-manager": "github:seredganyha/text-manager#main",
     "tslib": "^2.3.0",
+    "uuid": "^10.0.0",
+    "xmldom": "^0.6.0",
     "zone.js": "~0.14.10"
   },
   "devDependencies": {
@@ -27,6 +30,8 @@
     "@angular/cli": "^18.2.2",
     "@angular/compiler-cli": "^18.2.0",
     "@types/jasmine": "~5.1.0",
+    "@types/uuid": "^10.0.0",
+    "@types/xmldom": "^0.1.34",
     "jasmine-core": "~5.2.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/src/app/core/workers/file-worker/file-worker.types.ts
+++ b/src/app/core/workers/file-worker/file-worker.types.ts
@@ -1,0 +1,23 @@
+import { RequestBase, ResponseStatus, WorkerResponse } from "../worker.types";
+
+export enum FileWorkerControls {
+  ReadFile = 'readFile',
+}
+
+export interface ReadFileRequest extends RequestBase {
+  control: FileWorkerControls.ReadFile;
+  payload: File;
+}
+
+export interface ReadFileResponse extends WorkerResponse<{
+  control: FileWorkerControls.ReadFile,
+  payload: string;
+  status: ResponseStatus,
+  requestId: string;
+}> {}
+
+export type FileWorkerRequestList = 
+  | ReadFileRequest
+
+export type FileWorkerResponseList = 
+  | ReadFileResponse

--- a/src/app/core/workers/file-worker/file.worker.ts
+++ b/src/app/core/workers/file-worker/file.worker.ts
@@ -1,0 +1,29 @@
+import { createResponse, sendResponse } from "../utils/worker-response.utils";
+import { ResponseStatus } from "../worker.types";
+import { FileWorkerControls, FileWorkerRequestList, ReadFileResponse } from "./file-worker.types";
+
+self.onmessage = async (event: MessageEvent<FileWorkerRequestList>) => {
+  const { requestId, control, payload } = event.data;
+
+  switch(control) {
+    case FileWorkerControls.ReadFile: 
+      readFileHandler(payload, requestId);
+  }
+};
+
+const fileToText = async (file: File): Promise<string> => {
+  return await file.text();
+};
+
+const readFileHandler = async (file: File , requestId: string): Promise<void> => {
+  const fileText: string = await fileToText(file);
+
+  const response =  createResponse<ReadFileResponse>({
+    control: FileWorkerControls.ReadFile,
+    payload: fileText,
+    status: ResponseStatus.Success,
+    requestId
+  });
+
+  sendResponse(response);
+}

--- a/src/app/core/workers/text-manager-worker/text-manager.d.ts
+++ b/src/app/core/workers/text-manager-worker/text-manager.d.ts
@@ -1,0 +1,22 @@
+declare module 'text-manager' {
+
+  export class TextManager {
+    // import() is used because the standard method cannot be used. View more details
+    // at: https://github.com/microsoft/TypeScript/issues/55019
+    // -__-  bruuh
+    constructor(
+      dom: Document, 
+      queueNode: QueueNode,
+      maxChar: number, 
+      indexes: import('./tm-worker.types').TMIndexes
+    )
+
+    getText(): string;
+    getIndexes(): import('./tm-worker.types').TMIndexes;
+    setIndexes(indexes: import('./tm-worker.types').TMIndexes): void;
+  }
+
+  export class QueueNode {
+    constructor() {}
+  }
+}

--- a/src/app/core/workers/text-manager-worker/text-manager.worker.ts
+++ b/src/app/core/workers/text-manager-worker/text-manager.worker.ts
@@ -1,0 +1,100 @@
+/// <reference lib="webworker" />
+
+import { createResponse, sendResponse } from "../utils/worker-response.utils";
+import { ResponseStatus } from "../worker.types";
+import { DOMParser } from "xmldom";
+
+import {
+  GetFragmentResponse,
+  GetIndexesResponse,
+  InitTMResponse,
+  RequestedTMOptions,
+  TMIndexes,
+  TMWorkerControls,
+  TMWorkerRequestList, 
+} from "./tm-worker.types";
+
+import {QueueNode, TextManager} from "text-manager"
+
+const queueNode = new QueueNode();
+let textManager: TextManager;
+
+
+self.onmessage = (event: MessageEvent<TMWorkerRequestList>) => {
+  const { control, payload, requestId } = event.data;
+
+  switch (control) {
+    case TMWorkerControls.GetIndexes:
+      getIndexesHandler(requestId);
+      break;
+    case TMWorkerControls.SetIndexes:
+      setIndexesHandler(payload, requestId);
+      break;
+    case TMWorkerControls.GetFragment:
+      getFragmentHandler(requestId);
+      break;
+    case TMWorkerControls.InitTM:
+      initTextManagerHandler(payload, requestId)
+  }
+};
+
+const setIndexesHandler = (indexes: TMIndexes, requestId: string) => {
+  textManager.setIndexes(indexes);
+
+  const response = createResponse<InitTMResponse>({
+    control: TMWorkerControls.InitTM,
+    requestId,
+    status: ResponseStatus.Success,
+  })
+
+  sendResponse(response);
+}
+
+const getIndexesHandler = (requestId: string) => {
+  let indexes: TMIndexes | undefined;
+
+  if (textManager) {
+    textManager.getIndexes()
+  }
+
+  const response = createResponse<GetIndexesResponse>({
+    control: TMWorkerControls.GetIndexes,
+    payload: indexes,
+    status: indexes ? ResponseStatus.Success: ResponseStatus.Error,
+    requestId
+  })
+
+  sendResponse(response)
+}
+
+const getFragmentHandler = (requestId: string) => {
+  let fragment!: string | undefined;
+
+  if (textManager) {
+    let fragment = textManager.getText();
+  }
+
+  const response = createResponse<GetFragmentResponse>({
+    control: TMWorkerControls.GetFragment,
+    payload: fragment,
+    status: fragment ? ResponseStatus.Success: ResponseStatus.Error,
+    requestId
+  })
+
+  sendResponse(response)
+}
+
+const initTextManagerHandler = (options: RequestedTMOptions, requestId: string) => {
+  const dom = new DOMParser().parseFromString(options.textDocument, "application/xml");
+
+  textManager = new TextManager(dom, queueNode, options.maxChar, options.indexes);
+
+  const response = createResponse<InitTMResponse>({
+    control: TMWorkerControls.InitTM,
+    requestId,
+    status: ResponseStatus.Success,
+  })
+
+  sendResponse(response);
+}
+

--- a/src/app/core/workers/text-manager-worker/tm-worker.types.ts
+++ b/src/app/core/workers/text-manager-worker/tm-worker.types.ts
@@ -1,0 +1,107 @@
+import { QueueNode } from "text-manager";
+import { RequestBase, ResponseStatus, WorkerResponse } from "../worker.types";
+
+export enum TMWorkerControls {
+  GetIndexes = 'getIndexes',
+  SetIndexes = 'setIndexes',
+  GetFragment = 'getFragment',
+  SetDOMBook = 'setDOMBook',
+  InitTM = 'initTM',
+}
+
+export type TMIndexes = [number, number]
+
+export interface TMOptions {
+  dom: Document,
+  queueNode: QueueNode,
+  maxChar: number,
+  indexes: TMIndexes
+}
+
+export interface RequestedTMOptions {
+  textDocument: string,
+  maxChar: number,
+  indexes: TMIndexes
+}
+
+//===============================\\
+//            REQUEST            \\
+//===============================\\
+
+
+export interface GetIndexesRequest extends RequestBase {
+  control: TMWorkerControls.GetIndexes;
+  payload: null;
+}
+
+export interface SetIndexesRequest extends RequestBase {
+  control: TMWorkerControls.SetIndexes;
+  payload: TMIndexes;
+}
+
+export interface GetFragmentRequest extends RequestBase {
+  control: TMWorkerControls.GetFragment;
+  payload?: null;
+}
+
+export interface SetDOMBookRequest extends RequestBase {
+  control: TMWorkerControls.SetDOMBook;
+  payload: Document;
+}
+
+export interface InitTMRequest extends RequestBase {
+  control: TMWorkerControls.InitTM;
+  payload: RequestedTMOptions;
+}
+
+export type TMWorkerRequestList =
+  | InitTMRequest
+  | GetIndexesRequest
+  | SetIndexesRequest
+  | GetFragmentRequest
+  | SetDOMBookRequest;
+
+//===============================\\
+//            RESPONSE           \\
+//===============================\\
+
+export interface GetIndexesResponse extends WorkerResponse<{ 
+  control: TMWorkerControls.GetIndexes, 
+  payload: TMIndexes, status: ResponseStatus,
+  requestId: string;
+}> {}
+  
+export interface SetIndexesResponse extends WorkerResponse<{ 
+  control: TMWorkerControls.SetIndexes, 
+  payload: null, 
+  status: ResponseStatus,
+  requestId: string;
+}> {}
+
+export interface GetFragmentResponse extends WorkerResponse<{ 
+  control: TMWorkerControls.GetFragment, 
+  payload: string, 
+  status: ResponseStatus,
+  requestId: string;
+}> {}
+
+export interface SetDOMBookResponse extends WorkerResponse<{ 
+  control: TMWorkerControls.SetDOMBook, 
+  payload: null, 
+  status: ResponseStatus,
+  requestId: string;
+}> {}
+
+export interface InitTMResponse extends WorkerResponse<{ 
+  control: TMWorkerControls.InitTM, 
+  payload: null, 
+  status: ResponseStatus,
+  requestId: string;
+}> {}
+
+export type TMWorkerResponseList = 
+  | GetIndexesResponse 
+  | SetIndexesResponse 
+  | GetFragmentResponse 
+  | SetDOMBookResponse
+  | InitTMResponse;

--- a/src/app/core/workers/utils/worker-response.utils.ts
+++ b/src/app/core/workers/utils/worker-response.utils.ts
@@ -1,0 +1,9 @@
+import { ResponseBase } from "../worker.types";
+
+export function sendResponse<T extends ResponseBase>(response: T) {
+  self.postMessage(response);
+}
+
+export function createResponse<T extends ResponseBase>(response: T): T {
+  return response;
+}

--- a/src/app/core/workers/worker.service.ts
+++ b/src/app/core/workers/worker.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from "@angular/core";
+import { RequestBase, ResponseBase, WorkerRequest, Workers } from "./worker.types";
+import { Subject } from "rxjs";
+
+@Injectable({
+  providedIn: 'root',
+})
+export class WorkerService {
+  private workers = new Map<Workers, Worker>();
+  private pendingRequests: Map<string, (response: ResponseBase) => void> = new Map();
+
+  constructor() {
+
+    this.init()
+
+    this.workers.forEach(worker => {
+      if (worker) {
+        worker.onmessage = (event: MessageEvent<ResponseBase>) => {
+          const { requestId } = event.data;
+          const pendingFn = this.pendingRequests.get(requestId);
+
+          if (pendingFn) {
+              pendingFn(event.data);
+          }
+        };
+      }
+    });
+  }
+
+  request<T extends RequestBase>(request: WorkerRequest<T>) {
+    const responseSubject = new Subject<ResponseBase>();
+
+    const waitPendingFn = (response: ResponseBase) => {
+      responseSubject.next(response);
+      responseSubject.complete(); 
+    };
+
+    this.workers.get(request.worker)?.postMessage(request);
+    this.pendingRequests.set(request.requestId, waitPendingFn)
+    return responseSubject.asObservable();
+  }
+
+  init() {
+    if (typeof Worker !== 'undefined') {
+
+      this.workers.set(
+        Workers.TMWorker, 
+        new Worker(new URL(`./text-manager-worker/text-manager.worker`, import.meta.url)
+      ))
+
+      this.workers.set(
+        Workers.FileWorker, 
+        new Worker(new URL(`./file-worker/file.worker`, import.meta.url)
+      ))
+    }
+  }
+}
+
+

--- a/src/app/core/workers/worker.types.ts
+++ b/src/app/core/workers/worker.types.ts
@@ -1,0 +1,38 @@
+export interface WorkerRequest<T extends RequestBase> {
+  control: T['control'];
+  payload?: T['payload'];
+  worker: Workers;
+  requestId: string;
+}
+
+export interface WorkerResponse<T extends ResponseBase> extends ResponseBase {
+  control: T['control'];
+  payload?: T['payload'];
+  requestId: string;
+}
+
+export interface RequestBase {
+  worker: Workers;
+  control: string;
+  payload?: any;
+  requestId: string;
+}
+
+export type RequestBaseNotId = Omit<RequestBase, "requestId">
+
+export interface ResponseBase {
+  control: string;
+  payload?: any;
+  status: ResponseStatus;
+  requestId: string;
+}
+
+export enum ResponseStatus {
+  Success = 'success',
+  Error = 'error'
+}
+
+export enum Workers {
+  FileWorker = 'fileWorker',
+  TMWorker = 'TMWorker',
+}

--- a/src/app/shared/file-select/file-select.component.html
+++ b/src/app/shared/file-select/file-select.component.html
@@ -1,0 +1,1 @@
+<input #input type="file" id="input" (change)="onChange(input.files?.[0])" />

--- a/src/app/shared/file-select/file-select.component.ts
+++ b/src/app/shared/file-select/file-select.component.ts
@@ -1,0 +1,17 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-file-select',
+  standalone: true,
+  imports: [],
+  templateUrl: './file-select.component.html',
+  styleUrl: './file-select.component.scss'
+})
+export class FileSelectComponent {
+  @Input() file!: File | undefined;
+  @Output() fileChange = new EventEmitter();
+
+  onChange(file: File | undefined) {
+    this.fileChange.emit(file)
+  }
+}

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -1,0 +1,3 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export const getUuid = () => uuidv4();

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -1,0 +1,15 @@
+/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/worker",
+    "lib": [
+      "es2018",
+      "webworker"
+    ],
+    "types": []
+  },
+  "include": [
+    "src/**/*.worker.ts"
+  ]
+}


### PR DESCRIPTION
Добавил: 

FileSelect
TextManagerWorker
FileWorker

Попытался типизировать и унифицировать общение между основным потоком и воркерами. 
Получилось где-то на 70% ((

Потом еще вскрылась проблемка с интеграцией.
Оказалось нельзя в воркер отправить doc: Document

а в воркере нельзя распарсить через DomParser, тока либы юзать. 
jsDom идеально подходит, но в воркере он тоже не робит.
нашел решение через xmldom, но там нет querySelector))) , а моя библа их юзает.
Нашел решение добавить библу query-Selector в мою либу. Пока тестирую.

Вопросы/Рассуждения:
- мейби Переделать воркеры на классы. Создать интерфейс с общими методами и implements/extends их от него ?

Вот такой способ работы норм c TextManagerWorker ?
Там просто надо по цепочке работать с TextManager. Типа сначала init тока потом getText.
<img width="683" alt="image" src="https://github.com/user-attachments/assets/b6908562-4b18-483f-8833-3d369d3ac6a6">


